### PR TITLE
Rework permissions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ ensure that websites for which the user only granted access to coarse location
 can still use `navigator.permissions.query({ name: "geolocation" })` and get
 back `"granted"`.
 
+An analysis of how possible permission states and transitions could look like is
+[here](permission-states.md).
+
 ## Permissions policy
 
 Section 11. defines a [policy-controlled

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ enum AccuracyMode {
   // The default accuracy mode.
   "default",
 
-  // Request high accuracy location. Equivalent to enableHighAccuracy=true.
+  // Request high accuracy location.
   "high",
 
   // Require approximate location.
@@ -137,8 +137,6 @@ enum AccuracyMode {
 Callers can pass `"approximate"` to request approximate location or `"high"` to
 request high accuracy.
 If `accuracyMode` is not set, it defaults to `"default"`.
-
-If `accuracyMode` is not `"default"` then `enableHighAccuracy` is ignored.
 
 ## Capability detection
 
@@ -167,33 +165,53 @@ parameter requires approximate location.
 
 ## Permissions
 
-Section 3.1 defines a powerful feature `"geolocation"`. The specification will
-be updated to define an additional powerful feature `"geolocation-approximate"`
-to control access to approximate location. The algorithms to interface with the
-`"geolocation-approximate"` powerful feature will be overridden to take into
-account the fact that `"geolocation"` is "stronger" than
-`"geolocation-approximate"` (for example, a site will be allowed to access
-approximate location data if it has either the `"geolocation-approximate"` or
-the `"geolocation"` permission).
+Section 3.1 defines a powerful feature `"geolocation"`. This will be updated to
+have a custom
+[PermissionDescriptor](https://w3c.github.io/permissions/#dom-permissiondescriptor)
+with an `accuracy` [aspect](https://w3c.github.io/permissions/#dfn-aspects):
+
+```webidl
+dictionary GeolocationPermissionDescriptor : PermissionDescriptor {
+  AccuracyMode accuracyMode = "default";
+}
+```
+
+`"high"` will be [stronger
+than](https://w3c.github.io/permissions/#ref-for-dfn-stronger-than-1)
+`"default"`, which will be stronger than `"approximate"`, so that if the user
+denies access to approximate location then the User Agent denies access to
+location at all, while if the user grants access to precise location, also
+approximate location is granted.
+
+The additional `"default"` value is needed for backwards compatibility, to
+ensure that websites for which the user only granted access to coarse location
+can still use `navigator.permissions.query({ name: "geolocation" })` and get
+back `"granted"`.
 
 ## Permissions policy
 
 Section 11. defines a [policy-controlled
 feature](https://www.w3.org/TR/permissions-policy/#policy-controlled-feature)
 `"geolocation"`. It will be updated to define an additional policy-controlled
-feature `"geolocation-approximate"`, also with a default value of `"self"`,
-corresponding to the `"geolocation-approximate"` powerful feature. The
-`"geolocation"` feature will imply the `"geolocation-approximate"` feature.
+feature `"geolocation-approximate"`, also with a default value of `"self"`, that
+will only allow approximate location. The `"geolocation"` feature will imply the
+`"geolocation-approximate"` feature.
 
 ## Request a position
 
 In Section 6.5, the [request a
 position](https://www.w3.org/TR/geolocation/#dfn-request-a-position) algorithm
-requests permission to use `"geolocation"`. It will be updated to request
-`"geolocation-approximate"` as a fallback (so that the user can grant only
-approximate geolocation even if the website requests access precise location
-data). Moreover, if the `PositionOptions` parameter specifies approximate
-location mode, it will only prompt for `"geolocation-approximate"`.
+requests permission to use `"geolocation"`. It will be updated to allow for
+three different prompt cases:
+
+1. If the website doesn't set `accuracyMode="approximate"`, the user will be
+   prompted to choose between approximate and precise location.
+2. If the website sets `accuracyMode="approximate"`, the user will only be
+   prompted for approximate location.
+3. If the website has already been granted approximate location (as result of a
+   request with `accuracyMode="approximate"`) and now requests precise
+   location, the user will be prompted to upgrade their choice from approximate
+   to precise location.
 
 ## Acquire a position
 
@@ -206,6 +224,8 @@ Additionally, the algorithm will be updated to handle acquired position
 estimates that do not satisfy the accuracy bound.
 
 # Alternatives considered
+
+## Reusing `enableHighAccuracy`
 
 A boolean option `enableHighAccuracy` is already specified and its default value
 is `false`.
@@ -225,3 +245,17 @@ are able to generate a precise estimate quickly without waiting for GPS.
 As a result, the behavior on most systems is not affected by the
 `enableHighAccuracy` option and many applications use the default value
 regardless of whether high accuracy is needed.
+
+We could consider treating `enableHighAccuracy=true` the same as
+`accuracyMode="high"`. However, that would have a small backwards
+compatibility issue with `navigator.permissions.query({ name: "geolocation" })`,
+since it could result in different prompting behaviours (while querying the
+permission state would only return one state).
+
+## A separate `geolocation-approximate` powerful feature
+
+Instead of customizing `geolocation`'s PermissionDescriptor, we could add a
+separate `geolocation-approximate` powerful feature. However, this was rejected
+because of a backwards compatibility problem, since
+`navigator.permissions.query({ name: "geolocation" })` must return `"granted"`
+even if the user granted approximate geolocation only.

--- a/permission-states.md
+++ b/permission-states.md
@@ -1,0 +1,129 @@
+# Approximate Geolocation - Permission states and transitions
+
+The `GeolocationPermissionDescriptor` will contain a new `accuracyMode` aspect:
+
+```webidl
+dictionary GeolocationPermissionDescriptor : PermissionDescriptor {
+  AccuracyMode accuracyMode = "default";
+}
+
+enum AccuracyMode {
+  "default",
+  "high",
+  "approximate"
+}
+```
+
+with the constraint that `"high"` is [stronger
+than](https://w3c.github.io/permissions/#ref-for-dfn-stronger-than-1)
+`"default"`, which is stronger than `"approximate"`.
+
+In particular, if `"approximate"` is `"denied"` then also the other ones will be
+`"denied"`, while  if `"high"` is `"granted"`  then also the other ones will be
+`"granted"`.
+
+Moreover, when `"high"` is `"denied"` (for example, this could also happen when
+access to precise location has been blocked via Permissions Policy) then
+`"default"` will behave exactly as `"approximate"`, so there are seven possible
+valid states for the `"geolocation"` permission:
+
+|    | `approximate` | `default` | `high`    |
+|----|:-------------:|:---------:|:---------:|
+| 1. | `denied`      | `denied`  | `denied`  |
+| 2. | `prompt`      | `prompt`  | `denied`  |
+| 3. | `allow`       | `allow`   | `denied`  |
+| 4. | `prompt`      | `prompt`  | `prompt`  |
+| 5. | `allow`       | `prompt`  | `prompt`  |
+| 6. | `allow`       | `allow`   | `prompt`  |
+| 7. | `allow`       | `allow`   | `allow`   |
+
+Transitions between those states are summarized in the following table:
+
+| Initial state | Website requests `"approximate"`                                                     | Website requests `"default"`                                                                                                                   | Website requests `"high"`                                                                                                                      |
+|---------------|--------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.            | No prompt, website gets `PERMISSION_DENIED`                                          | No prompt, website gets `PERMISSION_DENIED`                                                                                                    | No prompt, website gets `PERMISSION_DENIED`                                                                                                    |
+| 2.            | Prompt for approximate only and transition to 3. (if granted) or 1. (if denied).     | Prompt for approximate only and transition to 3. (if granted) or 1. (if denied).                                                               | No prompt, website gets `PERMISSION_DENIED`                                                                                                    |
+| 3.            | Return approximate location.                                                         | Return approximate location.                                                                                                                   | No prompt, website gets `PERMISSION_DENIED`                                                                                                    |
+| 4.            | Prompt for approximate location and transition to 5. if granted. or 1. (if denied).  | Prompt for either approximate or precise location and transition to 6. (if granted approximate) and 7. (if granted precise) or 1. (if denied). | Prompt for either approximate or precise location and transition to 3. (if granted approximate) and 7. (if granted precise) or 1. (if denied). |
+| 5.            | Return approximate location.                                                         | Prompt to upgrade from approximate to precise location and transition to 7. (if granted) or 3. (if denied).                                    | Prompt to upgrade from approximate to precise location and transition to 7. (if granted) or 3. (if denied).                                    |
+| 6.            | Return approximate location.                                                         | Return approximate location.                                                                                                                   | Prompt to upgrade from approximate to precise location and transition to 7. (if granted) or 3. (if denied).                                    |
+| 7.            | Return approximate location.                                                         | Return precise location.                                                                                                                       | Return precise location.                                                                                                                       |
+
+and in the following diagram:
+
+```mermaid
+graph TD;
+    subgraph Legend
+      direction LR
+      start1[ ] -.->|website requests approx.| stop1[ ]
+      style start1 height:0px;
+      style stop1 height:0px;
+      start2[ ] -->|website requests default| stop2[ ]
+      style start2 height:0px;
+      style stop2 height:0px;
+      start3[ ] ==>|website requests precise| stop3[ ]
+      style start3 height:0px;
+      style stop3 height:0px;
+      start4[ ] -->|user grants approx.| stop4[ ]
+      style start4 height:0px;
+      style stop4 height:0px;
+      start5[ ] -->|user grants default| stop5[ ]
+      style start5 height:0px;
+      style stop5 height:0px;
+      start6[ ] -->|user denies| stop6[ ]
+      style start6 height:0px;
+      style stop6 height:0px;
+      linkStyle 3 stroke:blue;
+      linkStyle 4 stroke:green;
+      linkStyle 5 stroke:red;
+    end
+    1[1<br>approximate: denied,<br>default: denied,<br>high: denied];
+    2[2<br>approximate: prompt,<br>default: prompt,<br>high: denied];
+    3[3<br>approximate: allow, <br>default: allow, <br>high: denied];
+    4[4<br>approximate: prompt,<br>default: prompt,<br>high: prompt];
+    5[5<br>approximate: allow, <br>default: prompt,<br>high: prompt];
+    6[6<br>approximate: allow, <br>default: allow, <br>high: prompt];
+    7[7<br>approximate: allow, <br>default: allow, <br>high: allow];
+    4-.->1;
+    4-->1;
+    4==>1;
+    4==>3;
+    4-.->5;
+    4-->6;
+    4-->7;
+    4==>7;
+    5-->7;
+    5-->3;
+    5==>7;
+    5==>3;
+    6==>7;
+    6==>3;
+    2-.->3;
+    2-->3;
+    2==>3;
+    2-.->1;
+    2-->1;
+    2==>1;
+    2~~~6;
+    6~~~1;
+    linkStyle 6 stroke:red;
+    linkStyle 7 stroke:red;
+    linkStyle 8 stroke:red;
+    linkStyle 9 stroke:blue;
+    linkStyle 10 stroke:blue;
+    linkStyle 11 stroke:blue;
+    linkStyle 12 stroke:green;
+    linkStyle 13 Stroke:green;
+    linkStyle 14 stroke:green;
+    linkStyle 15 stroke:red;
+    linkStyle 16 stroke:green;
+    linkStyle 17 stroke:red;
+    linkStyle 18 stroke:green;
+    linkStyle 19 stroke:red;
+    linkStyle 20 stroke:blue;
+    linkStyle 21 stroke:blue;
+    linkStyle 22 stroke:blue;
+    linkStyle 23 stroke:red;
+    linkStyle 24 stroke:red;
+    linkStyle 25 stroke:red;
+```


### PR DESCRIPTION
Rework the permissions section, so that instead of adding a new powerful feature "geolocation-approximate" we define a custom PermissionDescriptor for "geolocation" that takes an additional accuracyMode aspect. This seems cleaner and simplifies the backward compatibility story (as explained in the change).

Having a separate powerful feature is still considered in the alternatives.

For the same backward compatibility reasons, this change also proposes not to treat `enableHighAccuracy=true` the same as `accuracyMode=high` anymore, but that is also listed as an alternative possibility.

Also add a diagram, separate from the explainer, listing possible states and transitions for geolocation permission.