### PR TITLE
Fix compilation error with [REPOSITORYURL] macro

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -20,7 +20,7 @@ Include Can I Use Panels: yes
 Introduction {#intro}
 =====================
 
-For now, see the [explainer]([REPOSITORYURL]).
+For now, see the <a href=[REPOSITORYURL]>explainer</a>.
 
 See [https://garykac.github.io/procspec/](https://garykac.github.io/procspec/),
 [https://dlaliberte.github.io/bikeshed-intro/index.html](https://dlaliberte.github.io/bikeshed-intro/index.html),


### PR DESCRIPTION
Macros don't expand in markdown links.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/approximate-geolocation/pull/2.html" title="Last updated on Mar 10, 2025, 12:43 PM UTC (9f860be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/explainers-by-googlers/approximate-geolocation/2/8b1821d...antosart:9f860be.html" title="Last updated on Mar 10, 2025, 12:43 PM UTC (9f860be)">Diff</a>